### PR TITLE
Support custom controller icons

### DIFF
--- a/lib/src/stickereditor.dart
+++ b/lib/src/stickereditor.dart
@@ -78,6 +78,12 @@ class StickerEditingView extends StatefulWidget {
   Color textModalBackgroundColor;
   String textModalConfirmText;
 
+  /// Custom controller Icons
+  final Icon? editIcon;
+  final Icon? resizeIcon;
+  final Icon? rotateIcon;
+  final Icon? closeIcon;
+
   /// Create a [StickerEditingBox] widget
   ///
   StickerEditingView(
@@ -89,6 +95,10 @@ class StickerEditingView extends StatefulWidget {
       this.width,
       this.onSave,
       this.backgroundColor,
+      this.editIcon,
+      this.resizeIcon,
+      this.rotateIcon,
+      this.closeIcon,
       this.viewOnly = false,
       this.texts = const [],
       this.pictures = const [],
@@ -218,6 +228,10 @@ class _StickerEditingViewState extends State<StickerEditingView> {
                           palletColor: widget.palletColor,
                           fonts: widget.fonts,
                           newText: v,
+                          editIcon: widget.editIcon,
+                          resizeIcon: widget.resizeIcon,
+                          closeIcon: widget.closeIcon,
+                          rotateIcon: widget.rotateIcon,
                           boundWidth: width * .90 - width * .20,
                           boundHeight: height * .70 - height * .07);
                     }).toList(),
@@ -251,6 +265,9 @@ class _StickerEditingViewState extends State<StickerEditingView> {
                               });
                             }
                           },
+                          resizeIcon: widget.resizeIcon,
+                          closeIcon: widget.closeIcon,
+                          rotateIcon: widget.rotateIcon,
                           boundWidth: width * .90,
                           boundHeight: height * .70,
                           pictureModel: v);

--- a/lib/src/widgets/sticker_widget/sticker_box.dart
+++ b/lib/src/widgets/sticker_widget/sticker_box.dart
@@ -20,6 +20,11 @@ class StickerEditingBox extends StatefulWidget {
 
   final bool viewOnly;
 
+  /// Custom controller Icons
+  final Icon? resizeIcon;
+  final Icon? rotateIcon;
+  final Icon? closeIcon;
+
   /// Create a [StickerEditingBox] widget
   ///
   /// [pictureModel] detail of your picture
@@ -31,6 +36,9 @@ class StickerEditingBox extends StatefulWidget {
       required this.boundHeight,
       required this.pictureModel,
       this.viewOnly = false,
+      this.resizeIcon,
+      this.rotateIcon,
+      this.closeIcon,
       this.onTap,
       this.onCancel})
       : super(key: key);
@@ -159,8 +167,9 @@ class _StickerEditingBoxState extends State<StickerEditingBox> {
                                     Border.all(color: Colors.black, width: 1),
                                 shape: BoxShape.circle,
                                 color: Colors.white),
-                            child: const Icon(Icons.sync_alt,
-                                color: Colors.black, size: 12),
+                            child: widget.rotateIcon ??
+                                const Icon(Icons.sync_alt,
+                                    color: Colors.black, size: 12),
                           )
                         : Container(),
                   ),
@@ -177,10 +186,15 @@ class _StickerEditingBoxState extends State<StickerEditingBox> {
                     },
                     child: widget.pictureModel.isSelected
                         ? Container(
-                            decoration: const BoxDecoration(
-                                shape: BoxShape.circle, color: Colors.white),
-                            child: const Icon(Icons.cancel_outlined,
-                                color: Colors.black, size: 18),
+                            padding: const EdgeInsets.all(2),
+                            decoration: BoxDecoration(
+                                border:
+                                    Border.all(color: Colors.black, width: 1),
+                                shape: BoxShape.circle,
+                                color: Colors.white),
+                            child: widget.closeIcon ??
+                                const Icon(Icons.close,
+                                    color: Colors.black, size: 12),
                           )
                         : Container(),
                   ),
@@ -206,8 +220,9 @@ class _StickerEditingBoxState extends State<StickerEditingBox> {
                                       Border.all(color: Colors.black, width: 1),
                                   color: Colors.white,
                                   shape: BoxShape.circle),
-                              child: const Icon(Icons.crop,
-                                  color: Colors.black, size: 12))
+                              child: widget.resizeIcon ??
+                                  const Icon(Icons.crop,
+                                      color: Colors.black, size: 12))
                           : Container()),
                 ),
               ],

--- a/lib/src/widgets/text_widget/text_box.dart
+++ b/lib/src/widgets/text_widget/text_box.dart
@@ -22,6 +22,12 @@ class TextEditingBox extends StatefulWidget {
   bool isSelected;
   bool viewOnly;
 
+  /// Custom controller Icons
+  final Icon? editIcon;
+  final Icon? resizeIcon;
+  final Icon? rotateIcon;
+  final Icon? closeIcon;
+
   /// Total Colors option that you want to give to user
   List<Color>? palletColor;
 
@@ -45,6 +51,10 @@ class TextEditingBox extends StatefulWidget {
       required this.boundWidth,
       required this.boundHeight,
       required this.fonts,
+      this.editIcon,
+      this.resizeIcon,
+      this.rotateIcon,
+      this.closeIcon,
       this.isSelected = false,
       this.viewOnly = false,
       this.onCancel,
@@ -215,10 +225,15 @@ class _TextEditingBoxState extends State<TextEditingBox> {
                     },
                     child: widget.isSelected
                         ? Container(
-                            decoration: const BoxDecoration(
-                                shape: BoxShape.circle, color: Colors.white),
-                            child: const Icon(Icons.cancel_outlined,
-                                color: Colors.black, size: 17),
+                            padding: const EdgeInsets.all(2),
+                            decoration: BoxDecoration(
+                                border:
+                                    Border.all(color: Colors.black, width: 1),
+                                shape: BoxShape.circle,
+                                color: Colors.white),
+                            child: widget.closeIcon ??
+                                const Icon(Icons.close,
+                                    color: Colors.black, size: 12),
                           )
                         : Container(),
                   ),
@@ -241,8 +256,9 @@ class _TextEditingBoxState extends State<TextEditingBox> {
                                     Border.all(color: Colors.black, width: 1),
                                 shape: BoxShape.circle,
                                 color: Colors.white),
-                            child: const Icon(Icons.edit,
-                                color: Colors.black, size: 10),
+                            child: widget.editIcon ??
+                                const Icon(Icons.edit,
+                                    color: Colors.black, size: 10),
                           )
                         : Container(),
                   ),
@@ -263,8 +279,9 @@ class _TextEditingBoxState extends State<TextEditingBox> {
                                     Border.all(color: Colors.black, width: 1),
                                 shape: BoxShape.circle,
                                 color: Colors.white),
-                            child: const Icon(Icons.rotate_right,
-                                color: Colors.black, size: 10),
+                            child: widget.rotateIcon ??
+                                const Icon(Icons.rotate_right,
+                                    color: Colors.black, size: 10),
                           )
                         : Container(),
                   ),
@@ -290,8 +307,9 @@ class _TextEditingBoxState extends State<TextEditingBox> {
                                     Border.all(color: Colors.black, width: 1),
                                 color: Colors.white,
                                 shape: BoxShape.circle),
-                            child: const Icon(Icons.crop,
-                                color: Colors.black, size: 10),
+                            child: widget.resizeIcon ??
+                                const Icon(Icons.crop,
+                                    color: Colors.black, size: 10),
                           )
                         : Container(),
                   ),


### PR DESCRIPTION
Added new parameters to specify custom icons.
Issue: #1 

```dart
StickerEditingView(
    rotateIcon: const Icon(
      Icons.heart_broken,
      size: 10,
      color: Colors.red,
    ), // Skip parameter to set default icon
    closeIcon: const Icon(
      Icons.star,
      size: 10,
      color: Colors.yellow,
    ), // Skip parameter to set default icon
    rotateIcon: const Icon(
      Icons.rectangle,
      size: 10,
      color: Colors.green,
    ), // Skip parameter to set default icon
)
```

![Screenshot 2024-04-20 at 12 29 52 PM](https://github.com/tinyjin/sticker_editor_plus/assets/11167117/eaa8cf6f-5706-4f10-9a42-5ad863b698be)

![Screenshot 2024-04-20 at 8 18 37 PM](https://github.com/tinyjin/sticker_editor_plus/assets/11167117/01971353-49ed-4624-9304-00379beeba27)
