### PR TITLE
Remove `isNetwork` status

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ Container(
           boundHeight: 200,
           boundWidth: 200,
           pictureModel: PictureModel(
-            isNetwork: true,
             isSelected: false,
             left: 50,
             top: 50,

--- a/example/lib/view.dart
+++ b/example/lib/view.dart
@@ -129,7 +129,6 @@ class _StickerEditingBoxScreenState extends State<StickerEditingBoxScreen> {
                 boundHeight: 200,
                 boundWidth: 200,
                 pictureModel: PictureModel(
-                  isNetwork: true,
                   isSelected: false,
                   left: 50,
                   top: 50,

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -140,26 +140,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -180,18 +180,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.15.0"
   path:
     dependency: transitive
     description:
@@ -307,7 +307,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.1.0"
   stream_channel:
     dependency: transitive
     description:
@@ -336,10 +336,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.2"
   typed_data:
     dependency: transitive
     description:
@@ -424,10 +424,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.5"
   web:
     dependency: transitive
     description:

--- a/lib/src/model/picture_model.dart
+++ b/lib/src/model/picture_model.dart
@@ -6,8 +6,6 @@ class PictureModel {
 
   /// Scale image
   double scale;
-  // This is your Image link type
-  bool isNetwork;
   double left;
 
   PictureModel(
@@ -16,17 +14,15 @@ class PictureModel {
       required this.isSelected,
       this.angle = 0,
       required this.scale,
-      required this.isNetwork,
       required this.left});
 
   PictureModel.fromJson(Map<String, dynamic> data)
-    : stringUrl = data['url'] ?? '',
-      top = data['top'] ?? 0,
-      left = data['left'] ?? 0,
-      angle = data['angle'] ?? 0,
-      scale = data['scale'] ?? 1,
-      isSelected = false,
-      isNetwork = (data['url'] ?? '').startsWith('http');
+      : stringUrl = data['url'] ?? '',
+        top = data['top'] ?? 0,
+        left = data['left'] ?? 0,
+        angle = data['angle'] ?? 0,
+        scale = data['scale'] ?? 1,
+        isSelected = false;
 
   Map<String, dynamic> toJson() {
     return {

--- a/lib/src/stickereditor.dart
+++ b/lib/src/stickereditor.dart
@@ -421,6 +421,8 @@ class _StickerEditingViewState extends State<StickerEditingView> {
                       crossAxisCount: 4),
                   itemCount: widget.assetList!.length,
                   itemBuilder: (BuildContext context, int index) {
+                    final asset = widget.assetList![index];
+                    final isNetwork = asset.startsWith('http');
                     return InkWell(
                       onTap: () {
                         for (var e in newimageList) {
@@ -430,7 +432,6 @@ class _StickerEditingViewState extends State<StickerEditingView> {
                           e.isSelected = false;
                         }
                         newimageList.add(PictureModel(
-                            isNetwork: false,
                             stringUrl: widget.assetList![index],
                             top: y1 + 10 < 300 ? y1 + 10 : 300,
                             isSelected: true,
@@ -442,8 +443,9 @@ class _StickerEditingViewState extends State<StickerEditingView> {
                         Navigator.pop(context);
                         setState(() {});
                       },
-                      child: Image.asset(widget.assetList![index],
-                          height: 50, width: 50),
+                      child: isNetwork
+                          ? Image.network(asset, height: 50, width: 50)
+                          : Image.asset(asset, height: 50, width: 50),
                     );
                   }),
             ),

--- a/lib/src/widgets/sticker_widget/sticker_box.dart
+++ b/lib/src/widgets/sticker_widget/sticker_box.dart
@@ -141,7 +141,7 @@ class _StickerEditingBoxState extends State<StickerEditingBox> {
                         ? Colors.grey[600]!
                         : Colors.transparent,
                     padding: const EdgeInsets.all(4),
-                    child: widget.pictureModel.isNetwork
+                    child: widget.pictureModel.stringUrl.startsWith('http')
                         ? Image.network(widget.pictureModel.stringUrl,
                             height: 50, width: 50)
                         : Image.asset(widget.pictureModel.stringUrl,


### PR DESCRIPTION
isNetwork is useless. Adapting better way of choosing between `Image.asset` and `Image.network`.

When the given asset starts with http in the link, library will show with `Image.network`