### PR TITLE
fix: correct sticker dragging behavior

### DIFF
--- a/lib/src/widgets/sticker_widget/sticker_box.dart
+++ b/lib/src/widgets/sticker_widget/sticker_box.dart
@@ -69,7 +69,7 @@ class _StickerEditingBoxState extends State<StickerEditingBox> {
           angle: widget.pictureModel.angle,
           child: GestureDetector(
             onScaleStart: (tap) {
-              setState(() => deltaOffset = const Offset(0, 0));
+              setState(() => deltaOffset = tap.focalPoint);
             },
             onScaleUpdate: (tap) {
               if (widget.viewOnly) {

--- a/lib/src/widgets/text_widget/text_box.dart
+++ b/lib/src/widgets/text_widget/text_box.dart
@@ -128,7 +128,7 @@ class _TextEditingBoxState extends State<TextEditingBox> {
           angle: widget.newText.angle,
           child: GestureDetector(
             onScaleStart: (tap) {
-              setState(() => deltaOffset = const Offset(0, 0));
+              setState(() => deltaOffset = tap.focalPoint);
             },
             onScaleUpdate: (tap) {
               if (widget.viewOnly) {


### PR DESCRIPTION
| Before                                               | After                                               |
|---------------------------------------------------------|-----------------------------------------------------------|
| ![CleanShot 우측](https://github.com/user-attachments/assets/b600941d-e763-4ca4-9f47-f656a4e57cfc) | ![CleanShot 좌측](https://github.com/user-attachments/assets/ba76142f-e929-4298-96dd-9beac6d3c118) | 


deltaOffset was incorrectly initialized to Offset(0, 0), causing absolute positioning instead of relative movement. Now initializes to tap.focalPoint for proper relative positioning.